### PR TITLE
v4.1 (slippage support)

### DIFF
--- a/src/utils/monero_utils.h
+++ b/src/utils/monero_utils.h
@@ -58,6 +58,7 @@
 #include "wallet/monero_wallet_model.h"
 #include "cryptonote_basic/cryptonote_basic.h"
 #include "serialization/keyvalue_serialization.h" // TODO: consolidate with other binary deps?
+#include "serialization/string.h"
 #include "storages/portable_storage.h"
 
 /**

--- a/src/wallet/monero_wallet_model.cpp
+++ b/src/wallet/monero_wallet_model.cpp
@@ -285,6 +285,7 @@ namespace monero {
     if (m_output_sum != boost::none) monero_utils::add_json_member("outputSum", m_output_sum.get(), allocator, root, value_num);
     if (m_change_amount != boost::none) monero_utils::add_json_member("changeAmount", m_change_amount.get(), allocator, root, value_num);
     if (m_collateral_amount != boost::none) monero_utils::add_json_member("collateralAmount", m_collateral_amount.get(), allocator, root, value_num);
+    if (m_slippage_amount != boost::none) monero_utils::add_json_member("slippageAmount", m_slippage_amount.get(), allocator, root, value_num);
     if (m_num_dummy_outputs != boost::none) monero_utils::add_json_member("numDummyOutputs", m_num_dummy_outputs.get(), allocator, root, value_num);
 
     // set string values

--- a/src/wallet/monero_wallet_model.h
+++ b/src/wallet/monero_wallet_model.h
@@ -291,6 +291,7 @@ namespace monero {
     boost::optional<std::string> m_change_address;
     boost::optional<uint64_t> m_change_amount;
     boost::optional<uint64_t> m_collateral_amount;
+    boost::optional<uint64_t> m_slippage_amount;
     boost::optional<uint32_t> m_num_dummy_outputs;
     boost::optional<std::string> m_extra_hex;
     rapidjson::Value to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const;


### PR DESCRIPTION
Update Haven core to 4.1.0
Fix a segfault in the logging system when calling the library directly
Add support for slippage in transactions